### PR TITLE
"dev-master" branch support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "require": {
-    "orchid/platform":"^6.0.0"
+    "orchid/platform":"^6.0.0|dev-master"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This package required for [orchidsoftware/press](https://github.com/orchidsoftware/press), and it doesn't make sense if that package doesn't support dev branch